### PR TITLE
Make stream.sh use blocking `gpiomon` instead of polling

### DIFF
--- a/scripts/stream.sh
+++ b/scripts/stream.sh
@@ -1,41 +1,35 @@
 #!/bin/bash
 
+DVR_PATH=/media
 SCREEN_MODE=$(</config/scripts/screen-mode)
 REC_FPS=$(</config/scripts/rec-fps)
 
 
-RUNNING=0
-STREAMING=0
+PID=0
+DVR_RUNNING=""
 
-gpio_chip="gpiochip4"
-gpio_offset="10"
-
-cd /media
-
+BUTTON=`gpiofind PIN_27`
 
 while true; do
-    if [ $(gpioget $gpio_chip $gpio_offset) -eq 0 ]; then
 
-        if [ $RUNNING -eq 0 ]; then
-            kill -15 $STREAMING
-            sleep 0.1
-            current_date=$(date +'%m-%d-%Y_%H-%M-%S')
-
-                pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE --dvr-framerate $REC_FPS --dvr-fmp4 --dvr record_${current_date}.mp4 &
-
-                RUNNING=$!
-        else
-                kill -15 $RUNNING
-                RUNNING=0
-                STREAMING=0
-        fi
+    if [ $PID -ne 0 ]; then
+        kill -15 $PID
         sleep 0.1
-    elif [ $STREAMING -eq 0 ]; then
-
-        pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE &
-
-        STREAMING=$!
-
     fi
-    sleep 0.2
+
+    if [ "$DVR_RUNNING" = "off" ]; then
+        current_date=$(date +'%m-%d-%Y_%H-%M-%S')
+        pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE --dvr-framerate $REC_FPS --dvr-fmp4 --dvr $DVR_PATH/record_${current_date}.mp4 &
+        PID=$!
+        DVR_RUNNING="on"
+    else
+        pixelpilot --osd --osd-elements video,wfbng --screen-mode $SCREEN_MODE &
+        PID=$!
+        DVR_RUNNING="off"
+    fi
+
+    # wait 2s to let user release the button
+    sleep 2
+    # Wait for button click
+    gpiomon -F "%e" -n 1 $BUTTON
 done


### PR DESCRIPTION
It is a bit simplified but the main changes are:

* it uses blocking `gpiomon` to wait for button clicks
* it uses `gpiofind` to find chip name and offset